### PR TITLE
fix gs shell search provider

### DIFF
--- a/src/gs-shell-search-provider.c
+++ b/src/gs-shell-search-provider.c
@@ -93,7 +93,7 @@ search_done_cb (GObject *source,
 		GsApp *app = gs_app_list_index (list, i);
 		if (gs_app_get_state (app) != AS_APP_STATE_AVAILABLE)
 			continue;
-		g_variant_builder_add (&builder, "s", gs_app_get_id (app));
+		g_variant_builder_add (&builder, "s", gs_app_get_unique_id (app));
 	}
 	g_dbus_method_invocation_return_value (search->invocation, g_variant_new ("(as)", &builder));
 
@@ -202,14 +202,14 @@ handle_get_result_metas (GsShellSearchProvider2	*skeleton,
 		}
 
 		g_variant_builder_init (&meta, G_VARIANT_TYPE ("a{sv}"));
-		g_variant_builder_add (&meta, "{sv}", "id", g_variant_new_string (gs_app_get_id (app)));
+		g_variant_builder_add (&meta, "{sv}", "id", g_variant_new_string (gs_app_get_unique_id (app)));
 		g_variant_builder_add (&meta, "{sv}", "name", g_variant_new_string (gs_app_get_name (app)));
 		pixbuf = gs_app_get_pixbuf (app);
 		if (pixbuf != NULL)
 			g_variant_builder_add (&meta, "{sv}", "icon", g_icon_serialize (G_ICON (pixbuf)));
 		g_variant_builder_add (&meta, "{sv}", "description", g_variant_new_string (gs_app_get_summary (app)));
 		meta_variant = g_variant_builder_end (&meta);
-		g_hash_table_insert (self->metas_cache, g_strdup (gs_app_get_id (app)), g_variant_ref_sink (meta_variant));
+		g_hash_table_insert (self->metas_cache, g_strdup (gs_app_get_unique_id (app)), g_variant_ref_sink (meta_variant));
 
 	}
 

--- a/src/gs-shell-search-provider.c
+++ b/src/gs-shell-search-provider.c
@@ -223,7 +223,7 @@ handle_activate_result (GsShellSearchProvider2 	     *skeleton,
 	string = g_strjoinv (" ", terms);
 
 	g_action_group_activate_action (G_ACTION_GROUP (app), "details",
-				  	g_variant_new ("(ss)", result, string));
+					g_variant_new ("(ss)", result, ""));
 
 	gs_shell_search_provider2_complete_activate_result (skeleton, invocation);
 	return TRUE;


### PR DESCRIPTION
In `handle_get_result_metas`  the function `gs_plugin_loader_get_app_by_id` returns empty app structure therefore when the user type a search in the desktop search bar no app results are shown.

The fix is in "search-provider: cache app data in search_done_cb".
I could not find a way to fix that function, so I implanted a work around. Using a greedy approach, I save the app data in a cache in the `search_done_cb`, instead of in the `handle_get_result_metas`. The result is more data stored in the cache.

Also to make it work, I had to pass an empty string instead of the search terms. (see "search-provider: pass empty string to details action").